### PR TITLE
Copy src to working directory on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "scripts": {
     "transpile": "node_modules/.bin/babel src -d build",
     "transpile-watch": "node_modules/.bin/babel src -d build -w",
-    "postinstall": "echo 'POSTINSTALL DIR:' && pwd && ls . && babel src -d build",
     "test": "mocha \"test/**/*.js\" --compilers js:babel-core/register",
     "test-watch": "npm run test -- --watch"
   },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "transpile": "node_modules/.bin/babel src -d build",
     "transpile-watch": "node_modules/.bin/babel src -d build -w",
-    "postinstall": "node_modules/.bin/babel src -d build",
+    "postinstall": "echo 'POSTINSTALL DIR:' && pwd && ls . && babel src -d build",
     "test": "mocha \"test/**/*.js\" --compilers js:babel-core/register",
     "test-watch": "npm run test -- --watch"
   },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "transpile": "babel src -d build",
     "transpile-watch": "babel src -d build -w",
-    "postinstall": "npm run transpile"
+    "postinstall": "npm run transpile",
     "test": "mocha \"test/**/*.js\" --compilers js:babel-core/register",
     "test-watch": "npm run test -- --watch"
   },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "transpile": "node_modules/.bin/babel src -d build",
     "transpile-watch": "node_modules/.bin/babel src -d build -w",
-    "postinstall": "npm run transpile",
+    "postinstall": "node_modules/.bin/babel src -d build",
     "test": "mocha \"test/**/*.js\" --compilers js:babel-core/register",
     "test-watch": "npm run test -- --watch"
   },

--- a/package.json
+++ b/package.json
@@ -14,13 +14,14 @@
     "node": ">=4"
   },
   "scripts": {
-    "transpile": "node_modules/.bin/babel src -d build",
-    "transpile-watch": "node_modules/.bin/babel src -d build -w",
+    "transpile": "babel src -d build",
+    "transpile-watch": "babel src -d build -w",
+    "postinstall": "npm run transpile"
     "test": "mocha \"test/**/*.js\" --compilers js:babel-core/register",
     "test-watch": "npm run test -- --watch"
   },
   "files": [
-    "index.js"
+    "src"
   ],
   "keywords": [
     ""


### PR DESCRIPTION
Add src to files array so that it's copied to the working directory before the postinstall transpile command runs.

I'm not sure it this is the best solution (obviously would probably be better to do this pre-publish and host the result on npm) - but until there's a better solution, I think this Closes #2 :smile: 