### PR TITLE
Handle multiple matching elements in text assertion

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,10 +21,10 @@ All assertions start with a [WebdriverIO-compatible selector](http://webdriver.i
 Then, we can add our assertion to the chain.
 
 - `expect(selector).to.be.there()` - Test whether the element exists.
-- `expect(selector).to.be.visible()` - Test whether or not the element is visible.
-- `expect(selector).to.have.text('string')` - Test the text value of the dom element against supplied string. Exact matches only.
-- `expect(selector).to.have.text(/regex/)` - Test the text value of the dom element against the supplied regular expression.
-- `expect(selector).to.have.count(number)` - Test how many elements exist in the dom with the supplied selector
+- `expect(selector).to.be.visible()` - Test whether or not at least one matching element is visible.
+- `expect(selector).to.have.text('string')` - Test the text value of the selected element(s) against supplied string. Succeeds if at least one element matches exactly.
+- `expect(selector).to.have.text(/regex/)` - Test the text value of the selected element(s) against the supplied regular expression. Succeeds if at least one element matches.
+- `expect(selector).to.have.count(number)` - Test how many elements exist in the dom with the supplied selector.
 
 You can also always add a `not` in there to negate the assertion:
 

--- a/src/assertions/text.js
+++ b/src/assertions/text.js
@@ -9,7 +9,8 @@ export default function text(client, chai, utils) {
             elementExists(client, selector);
         }
 
-        const textArray = client.$$(selector).getText();
+        const getText = client.getText(selector);
+        const textArray = (getText instanceof Array) ? getText : [getText];
 
         var elementTextAsExpected;
         if (expected instanceof RegExp) {

--- a/src/assertions/text.js
+++ b/src/assertions/text.js
@@ -9,8 +9,7 @@ export default function text(client, chai, utils) {
             elementExists(client, selector);
         }
 
-        const elementText = client.getText(selector);
-        const textArray = (elementText instanceof Array) ? elementText : [elementText];
+        const textArray = client.$$(selector).getText();
 
         var elementTextAsExpected;
         if (expected instanceof RegExp) {
@@ -21,8 +20,8 @@ export default function text(client, chai, utils) {
 
         this.assert(
             elementTextAsExpected,
-            `Expected element <${selector}> to contain text "${expected}", but it contains "${elementText}" instead.`,
-            `Expected element <${selector}> not to contain text "${expected}", but it contains "${elementText}".`
+            `Expected element <${selector}> to contain text "${expected}", but only found [${textArray}].`,
+            `Expected element <${selector}> not to contain text "${expected}", but only found [${textArray}].`
         );
     });
 }

--- a/src/assertions/text.js
+++ b/src/assertions/text.js
@@ -10,12 +10,13 @@ export default function text(client, chai, utils) {
         }
 
         const elementText = client.getText(selector);
+        const textArray = (elementText instanceof Array) ? elementText : [elementText];
 
         var elementTextAsExpected;
-        if (typeof(expected) == "string") {
-            elementTextAsExpected = elementText === expected;
+        if (expected instanceof RegExp) {
+            elementTextAsExpected = textArray.some(text => text.match(expected));
         } else {
-            elementTextAsExpected = elementText.match(expected);
+            elementTextAsExpected = textArray.some(text => text === expected);
         }
 
         this.assert(

--- a/src/assertions/text.js
+++ b/src/assertions/text.js
@@ -21,8 +21,8 @@ export default function text(client, chai, utils) {
 
         this.assert(
             elementTextAsExpected,
-            `Expected element <${selector}> to contain text "${expected}", but only found [${textArray}].`,
-            `Expected element <${selector}> not to contain text "${expected}", but only found [${textArray}].`
+            `Expected element <${selector}> to contain text "${expected}", but only found: ${textArray}`,
+            `Expected element <${selector}> not to contain text "${expected}", but found: ${textArray}`
         );
     });
 }

--- a/src/assertions/value.js
+++ b/src/assertions/value.js
@@ -10,18 +10,19 @@ export default function value(client, chai, utils) {
         }
 
         const elementValue = client.getValue(selector);
+        const valueArray = (elementValue instanceof Array) ? elementValue : [elementValue];
 
         var elementValueAsExpected;
         if (typeof(expected) == "string") {
-            elementValueAsExpected = elementValue === expected;
+            elementValueAsExpected = valueArray.some(value => value === expected);
         } else {
-            elementValueAsExpected = elementValue.match(expected);
+            elementValueAsExpected = valueArray.some(value => value.match(expected));
         }
 
         this.assert(
             elementValueAsExpected,
-            `Expected element <${selector}> to contain value "${expected}", but it contains "${elementValue}" instead.`,
-            `Expected element <${selector}> not to contain value "${expected}", but it contains "${elementValue}".`
+            `Expected an element matching <${selector}> to contain value "${expected}", but only found these values: ${valueArray}`,
+            `Expected an element matching <${selector}> not to contain value "${expected}", but found these values: ${valueArray}`
         );
     });
 }

--- a/src/assertions/visible.js
+++ b/src/assertions/visible.js
@@ -10,10 +10,12 @@ export default function visible(client, chai, utils) {
             elementExists(client, selector, negate);
         }
 
-        const isVisible = client.$$(selector).isVisible().includes(true);
+        const isVisible = client.isVisible();
+        const visibleArray = (Array.isArray(isVisible)) ? isVisible : [isVisible];
+        const anyVisible = visibleArray.includes(true);
 
         this.assert(
-            isVisible,
+            anyVisible,
             `Expected ${selector} to be visible but it is not`,
             `Expected ${selector} to not be visible but it is`
         );

--- a/src/assertions/visible.js
+++ b/src/assertions/visible.js
@@ -10,7 +10,7 @@ export default function visible(client, chai, utils) {
             elementExists(client, selector, negate);
         }
 
-        const isVisible = client.isVisible(selector);
+        const isVisible = client.$$(selector).isVisible().includes(true);
 
         this.assert(
             isVisible,

--- a/test/assertions/text-test.js
+++ b/test/assertions/text-test.js
@@ -24,7 +24,6 @@ chai.use(sinonChai);
 describe('text', () => {
     beforeEach(() => {
         fakeClient.__resetStubs__();
-        fakeClient.$$.returns({getText: () => []});
         elementExists.reset();
     });
 
@@ -47,7 +46,7 @@ describe('text', () => {
             let elementText = 'Never gonna give you up';
             beforeEach(() => {
               elementExists.returns();
-              fakeClient.$$.returns({getText: () => [elementText]});
+              fakeClient.getText.returns(elementText);
             });
 
             describe('When call is chained with Immediately', () => {
@@ -118,7 +117,7 @@ describe('text', () => {
             let elementTexts = ['Never gonna give you up', 'Never gonna let you down'];
             beforeEach(() => {
                 elementExists.returns();
-                fakeClient.$$.returns({getText: () => elementTexts});
+                fakeClient.getText.returns(elementTexts);
             });
 
             describe("When at least one element's text matches string expectation", () => {

--- a/test/assertions/text-test.js
+++ b/test/assertions/text-test.js
@@ -24,6 +24,7 @@ chai.use(sinonChai);
 describe('text', () => {
     beforeEach(() => {
         fakeClient.__resetStubs__();
+        fakeClient.$$.returns({getText: () => []});
         elementExists.reset();
     });
 
@@ -42,92 +43,36 @@ describe('text', () => {
         });
 
 
-        describe('When multiple elements exists', () => {
-            let testResult = ['Never gonna give you up', 'Never gonna let you down'];
-            beforeEach(() => {
-                elementExists.returns();
-                fakeClient.getText.returns(testResult);
-            });
-
-            describe("When at least one element's text matches string expectation", () => {
-                it('Should not throw an error', () => {
-                    expect('.some-selector').to.have.text(testResult[0]);
-                });
-
-                describe('When negated', () => {
-                    it('Should throw an error', () => {
-                        expect(() => expect('.some-selector').to.not.have.text(testResult[0])).to.throw();
-                    });
-                });
-            });
-
-            describe("When at least one element's text matches regex expectation", () => {
-                it('Should not throw an error', () => {
-                    expect('.some-selector').to.have.text(/gon+a give/);
-                });
-
-                describe('When negated', () => {
-                    it('Should throw an error', () => {
-                        expect(() => expect('.some-selector').to.not.have.text(/gon+a give/)).to.throw();
-                    });
-                });
-            });
-
-            describe('When no element text matches string expectation', () => {
-                it('Should throw an error', () => {
-                    expect(() => expect('.some-selector').to.have.text("dis don't match jack! 1#43@")).to.throw();
-                });
-
-                describe('When negated', () => {
-                    it('Should not throw an error', () => {
-                        expect('.some-selector').to.not.have.text("dis don't match jack! 1#43@");
-                    });
-                });
-            });
-
-            describe('When no element text matches regex expectation', () => {
-                it('Should throw an error', () => {
-                    expect(() => expect('.some-selector').to.have.text(/dis don't match jack! 1#43@/)).to.throw();
-                });
-
-                describe('When negated', () => {
-                    it('Should not throw an error', () => {
-                        expect('.some-selector').to.not.have.text(/dis don't match jack! 1#43@/);
-                    });
-                });
-            });
-        });
-
         describe('When element exists', () => {
-            let testResult = 'Never gonna give you up';
+            let elementText = 'Never gonna give you up';
             beforeEach(() => {
-                elementExists.returns();
-                fakeClient.getText.returns(testResult);
+              elementExists.returns();
+              fakeClient.$$.returns({getText: () => [elementText]});
             });
 
             describe('When call is chained with Immediately', () => {
                 it('Should not wait till the element exists', () => {
-                    expect('.some-selector').to.have.immediately().text(testResult);
+                    expect('.some-selector').to.have.immediately().text(elementText);
                     expect(elementExists).to.not.have.been.called;
                 });
                 it('Should not throw an exception', () => {
-                    expect('.some-selector').to.have.immediately().text(testResult);
+                    expect('.some-selector').to.have.immediately().text(elementText);
                 });
                 describe('When negated', () => {
                     it('Should throw an error', () => {
-                        expect(() => expect('.some-selector').to.not.have.immediately().text(testResult)).to.throw();
+                        expect(() => expect('.some-selector').to.not.have.immediately().text(elementText)).to.throw();
                     });
                 });
             });
 
             describe('When element text matches string expectation', () => {
                 it('Should not throw an error', () => {
-                    expect('.some-selector').to.have.text(testResult);
+                    expect('.some-selector').to.have.text(elementText);
                 });
 
                 describe('When negated', () => {
                     it('Should throw an error', () => {
-                        expect(() => expect('.some-selector').to.not.have.text(testResult)).to.throw();
+                        expect(() => expect('.some-selector').to.not.have.text(elementText)).to.throw();
                     });
                 });
             });
@@ -157,6 +102,62 @@ describe('text', () => {
             });
 
             describe('When element text does not match regex expectation', () => {
+                it('Should throw an error', () => {
+                    expect(() => expect('.some-selector').to.have.text(/dis don't match jack! 1#43@/)).to.throw();
+                });
+
+                describe('When negated', () => {
+                    it('Should not throw an error', () => {
+                        expect('.some-selector').to.not.have.text(/dis don't match jack! 1#43@/);
+                    });
+                });
+            });
+        });
+
+        describe('When multiple elements exists', () => {
+            let elementTexts = ['Never gonna give you up', 'Never gonna let you down'];
+            beforeEach(() => {
+                elementExists.returns();
+                fakeClient.$$.returns({getText: () => elementTexts});
+            });
+
+            describe("When at least one element's text matches string expectation", () => {
+                it('Should not throw an error', () => {
+                    expect('.some-selector').to.have.text(elementTexts[0]);
+                });
+
+                describe('When negated', () => {
+                    it('Should throw an error', () => {
+                        expect(() => expect('.some-selector').to.not.have.text(elementTexts[0])).to.throw();
+                    });
+                });
+            });
+
+            describe("When at least one element's text matches regex expectation", () => {
+                it('Should not throw an error', () => {
+                    expect('.some-selector').to.have.text(/gon+a give/);
+                });
+
+                describe('When negated', () => {
+                    it('Should throw an error', () => {
+                        expect(() => expect('.some-selector').to.not.have.text(/gon+a give/)).to.throw();
+                    });
+                });
+            });
+
+            describe('When no element text matches string expectation', () => {
+                it('Should throw an error', () => {
+                    expect(() => expect('.some-selector').to.have.text("dis don't match jack! 1#43@")).to.throw();
+                });
+
+                describe('When negated', () => {
+                    it('Should not throw an error', () => {
+                        expect('.some-selector').to.not.have.text("dis don't match jack! 1#43@");
+                    });
+                });
+            });
+
+            describe('When no element text matches regex expectation', () => {
                 it('Should throw an error', () => {
                     expect(() => expect('.some-selector').to.have.text(/dis don't match jack! 1#43@/)).to.throw();
                 });

--- a/test/assertions/text-test.js
+++ b/test/assertions/text-test.js
@@ -28,11 +28,74 @@ describe('text', () => {
     });
 
     describe('When in synchronous mode', () => {
-        it('Should throw element doesn\'t exist error', () => {
+        context("when element doesn't exist", () => {
             const testError = 'foobar';
-            elementExists.throws(new Error(testError));
-            expect(() => expect('.some-selector').to.have.text('blablabla')).to.throw(testError);
-            expect(elementExists).to.have.been.calledOnce;
+            beforeEach(() => { elementExists.throws(new Error(testError)); });
+
+            it('Should throw element doesn\'t exist error for strings', () => {
+                expect(() => expect('.some-selector').to.have.text('blablabla')).to.throw(testError);
+                expect(elementExists).to.have.been.calledOnce;
+            });
+            it('Should throw element doesn\'t exist error for regular expressions', () => {
+              expect(() => expect('.some-selector').to.have.text(/blablabla/)).to.throw(testError);
+            });
+        });
+
+
+        describe('When multiple elements exists', () => {
+            let testResult = ['Never gonna give you up', 'Never gonna let you down'];
+            beforeEach(() => {
+                elementExists.returns();
+                fakeClient.getText.returns(testResult);
+            });
+
+            describe("When at least one element's text matches string expectation", () => {
+                it('Should not throw an error', () => {
+                    expect('.some-selector').to.have.text(testResult[0]);
+                });
+
+                describe('When negated', () => {
+                    it('Should throw an error', () => {
+                        expect(() => expect('.some-selector').to.not.have.text(testResult[0])).to.throw();
+                    });
+                });
+            });
+
+            describe("When at least one element's text matches regex expectation", () => {
+                it('Should not throw an error', () => {
+                    expect('.some-selector').to.have.text(/gon+a give/);
+                });
+
+                describe('When negated', () => {
+                    it('Should throw an error', () => {
+                        expect(() => expect('.some-selector').to.not.have.text(/gon+a give/)).to.throw();
+                    });
+                });
+            });
+
+            describe('When no element text matches string expectation', () => {
+                it('Should throw an error', () => {
+                    expect(() => expect('.some-selector').to.have.text("dis don't match jack! 1#43@")).to.throw();
+                });
+
+                describe('When negated', () => {
+                    it('Should not throw an error', () => {
+                        expect('.some-selector').to.not.have.text("dis don't match jack! 1#43@");
+                    });
+                });
+            });
+
+            describe('When no element text matches regex expectation', () => {
+                it('Should throw an error', () => {
+                    expect(() => expect('.some-selector').to.have.text(/dis don't match jack! 1#43@/)).to.throw();
+                });
+
+                describe('When negated', () => {
+                    it('Should not throw an error', () => {
+                        expect('.some-selector').to.not.have.text(/dis don't match jack! 1#43@/);
+                    });
+                });
+            });
         });
 
         describe('When element exists', () => {

--- a/test/assertions/value-test.js
+++ b/test/assertions/value-test.js
@@ -35,7 +35,7 @@ describe('value', () => {
             expect(elementExists).to.have.been.calledOnce;
         });
 
-        describe('When element exists', () => {
+        describe('When matching element exists', () => {
             let testResult = 'Never gonna give you up';
             beforeEach(() => {
                 elementExists.returns();
@@ -94,6 +94,62 @@ describe('value', () => {
             });
 
             describe('When element value does not match regex expectation', () => {
+                it('Should throw an error', () => {
+                    expect(() => expect('.some-selector').to.have.value(/dis don't match jack! 1#43@/)).to.throw();
+                });
+
+                describe('When negated', () => {
+                    it('Should not throw an error', () => {
+                        expect('.some-selector').to.not.have.value(/dis don't match jack! 1#43@/);
+                    });
+                });
+            });
+        });
+
+        describe('When multiple elements match', () => {
+            let testResult = ['Never gonna give you up', 'Never gonna let you down'];
+            beforeEach(() => {
+                elementExists.returns();
+                fakeClient.getValue.returns(testResult);
+            });
+
+            describe('When at least one element value matches string expectation', () => {
+                it('Should not throw an error', () => {
+                    expect('.some-selector').to.have.value(testResult[0]);
+                });
+
+                describe('When negated', () => {
+                    it('Should throw an error', () => {
+                        expect(() => expect('.some-selector').to.not.have.value(testResult[0])).to.throw();
+                    });
+                });
+            });
+
+            describe('When at least one element value matches regex expectation', () => {
+                it('Should not throw an error', () => {
+                    expect('.some-selector').to.have.value(/gon+a give/);
+                });
+
+                describe('When negated', () => {
+                    it('Should throw an error', () => {
+                        expect(() => expect('.some-selector').to.not.have.value(/gon+a give/)).to.throw();
+                    });
+                });
+            });
+
+            describe('When no element value matches string expectation', () => {
+                it('Should throw an error', () => {
+                    expect(() => expect('.some-selector').to.have.value("dis don't match jack! 1#43@")).to.throw();
+                });
+
+                describe('When negated', () => {
+                    it('Should not throw an error', () => {
+                        expect('.some-selector').to.not.have.value("dis don't match jack! 1#43@");
+                    });
+                });
+            });
+
+            describe('When no element value matches regex expectation', () => {
                 it('Should throw an error', () => {
                     expect(() => expect('.some-selector').to.have.value(/dis don't match jack! 1#43@/)).to.throw();
                 });

--- a/test/assertions/visible-test.js
+++ b/test/assertions/visible-test.js
@@ -23,6 +23,7 @@ chai.use(sinonChai);
 describe('visible', () => {
     beforeEach(() => {
         fakeClient.__resetStubs__();
+        fakeClient.$$.returns({isVisible: () => [false]});
         elementExists.reset();
         // Reset doesn't reset throws :(
         elementExists.returns();
@@ -47,7 +48,7 @@ describe('visible', () => {
             describe('When element is visible', () => {
                 beforeEach(() => {
                     elementExists.returns();
-                    fakeClient.isVisible.returns(true);
+                    fakeClient.$$.returns({isVisible: () => [true]});
                 });
 
                 describe('When call is chained with Immediately', () => {
@@ -64,6 +65,66 @@ describe('visible', () => {
                 describe('When negated', () => {
                     it('Should throw an exception', () => {
                         expect(() => expect('.some-selector').to.not.be.visible()).to.throw();
+                    });
+                });
+            });
+
+            describe('When element is not visible', () => {
+                beforeEach(() => {
+                    elementExists.returns();
+                    fakeClient.$$.returns({isVisible: () => [false]});
+                });
+
+                it('Should throw an exception', () => {
+                    expect(() => expect('.some-selector').to.be.visible()).to.throw();
+                });
+
+                describe('When negated', () => {
+                    it('Should not throw an exception', () => {
+                        expect('.some-selector').to.not.be.visible();
+                    });
+                });
+            });
+        });
+
+        describe('When multiple matching elements exists', () => {
+            describe('When any one is visible', () => {
+                beforeEach(() => {
+                    elementExists.returns();
+                    fakeClient.$$.returns({isVisible: () => [true, false]});
+                });
+
+                describe('When call is chained with Immediately', () => {
+                    it('Should not wait for the element to exist', () => {
+                        expect('.some-selector').to.be.immediately().visible();
+                        expect(elementExists).to.not.have.been.called;
+                    });
+                });
+
+                it('Should not throw an exception', () => {
+                    expect('.some-selector').to.be.visible();
+                });
+
+                describe('When negated', () => {
+                    it('Should throw an exception', () => {
+                        expect(() => expect('.some-selector').to.not.be.visible()).to.throw();
+                    });
+                });
+            });
+
+            describe('When none are visible', () => {
+                beforeEach(() => {
+                    elementExists.returns();
+                    fakeClient.$$.returns({isVisible: () => [false, false]});
+                });
+
+                it('Should throw an exception', () => {
+                    expect(() => expect('.some-selector').to.be.visible()).to.throw();
+                });
+
+                describe('When negated', () => {
+                    it('Should not throw an exception', () => {
+                        expect('.some-selector').to.not.be.visible();
                     });
                 });
             });

--- a/test/assertions/visible-test.js
+++ b/test/assertions/visible-test.js
@@ -23,7 +23,6 @@ chai.use(sinonChai);
 describe('visible', () => {
     beforeEach(() => {
         fakeClient.__resetStubs__();
-        fakeClient.$$.returns({isVisible: () => [false]});
         elementExists.reset();
         // Reset doesn't reset throws :(
         elementExists.returns();
@@ -48,7 +47,7 @@ describe('visible', () => {
             describe('When element is visible', () => {
                 beforeEach(() => {
                     elementExists.returns();
-                    fakeClient.$$.returns({isVisible: () => [true]});
+                    fakeClient.isVisible.returns(true);
                 });
 
                 describe('When call is chained with Immediately', () => {
@@ -72,7 +71,7 @@ describe('visible', () => {
             describe('When element is not visible', () => {
                 beforeEach(() => {
                     elementExists.returns();
-                    fakeClient.$$.returns({isVisible: () => [false]});
+                    fakeClient.isVisible.returns(false);
                 });
 
                 it('Should throw an exception', () => {
@@ -91,7 +90,7 @@ describe('visible', () => {
             describe('When any one is visible', () => {
                 beforeEach(() => {
                     elementExists.returns();
-                    fakeClient.$$.returns({isVisible: () => [true, false]});
+                    fakeClient.isVisible.returns([true, false]);
                 });
 
                 describe('When call is chained with Immediately', () => {
@@ -115,7 +114,7 @@ describe('visible', () => {
             describe('When none are visible', () => {
                 beforeEach(() => {
                     elementExists.returns();
-                    fakeClient.$$.returns({isVisible: () => [false, false]});
+                    fakeClient.isVisible.returns([false, false]);
                 });
 
                 it('Should throw an exception', () => {


### PR DESCRIPTION
When multiple elements match selector, text assertion was failing

- Added tests
- Fixed assertion

**Update:** Added the same fix for `visible` assertion