### PR TITLE
Fix isVisible selector bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 
-## Unreleased Changes:
+## 0.4.1:
+
+**Bug Fixes:**
+- fix error in `visible` assertion introduced in `0.4.0`
+
+## 0.4.0:
 
 **Breaking Changes:**
 - elementExists not requires 4 arguments instead of 3, to account for defaultWait time.

--- a/src/assertions/visible.js
+++ b/src/assertions/visible.js
@@ -12,7 +12,7 @@ export default function visible(client, chai, utils, options) {
           elementExists(client, selector, config.defaultWait, negate);
         }
 
-        const isVisible = client.isVisible();
+        const isVisible = client.isVisible(selector);
         const visibleArray = (Array.isArray(isVisible)) ? isVisible : [isVisible];
         const anyVisible = visibleArray.includes(true);
 

--- a/test/assertions/visible-test.js
+++ b/test/assertions/visible-test.js
@@ -26,9 +26,12 @@ describe('visible', () => {
         elementExists.reset();
         // Reset doesn't reset throws :(
         elementExists.returns();
+        fakeClient.isVisible.throws("ArgumentError");
+        fakeClient.isVisible.withArgs('.some-selector').returns(false);
     });
 
     describe('When in synchronous mode', () => {
+
         it('Should throw element doesn\'t exist error', () => {
             const testError = 'foobar';
             elementExists.throws(new Error(testError));
@@ -44,10 +47,11 @@ describe('visible', () => {
         });
 
         describe('When element exists', () => {
+            beforeEach(() => { elementExists.returns(); });
+
             describe('When element is visible', () => {
                 beforeEach(() => {
-                    elementExists.returns();
-                    fakeClient.isVisible.returns(true);
+                    fakeClient.isVisible.withArgs('.some-selector').returns(true);
                 });
 
                 context('When given a defaultWait time', () => {
@@ -80,11 +84,6 @@ describe('visible', () => {
             });
 
             describe('When element is not visible', () => {
-                beforeEach(() => {
-                    elementExists.returns();
-                    fakeClient.isVisible.returns(false);
-                });
-
                 it('Should throw an exception', () => {
                     expect(() => expect('.some-selector').to.be.visible()).to.throw();
                 });
@@ -101,7 +100,7 @@ describe('visible', () => {
             describe('When any one is visible', () => {
                 beforeEach(() => {
                     elementExists.returns();
-                    fakeClient.isVisible.returns([true, false]);
+                    fakeClient.isVisible.withArgs('.some-selector').returns([true, false]);
                 });
 
                 describe('When call is chained with Immediately', () => {
@@ -125,7 +124,7 @@ describe('visible', () => {
             describe('When none are visible', () => {
                 beforeEach(() => {
                     elementExists.returns();
-                    fakeClient.isVisible.returns([false, false]);
+                    fakeClient.isVisible.withArgs('.some-selector').returns([false, false]);
                 });
 
                 it('Should throw an exception', () => {


### PR DESCRIPTION
Currently, using isVisible fails with an error, due to a typo in the assertion that omits the selector when calling `client.isVisible`.  This adds regression tests and fixes the bug.

- Adjust tests to ensure isVisible is called with correct selector
- Make tests pass
- Update Changelog