### PR TITLE
Release v0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chai-webdriverio",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Chai assertions for use with webdriverio",
   "license": "Apache-2.0",
   "repository": "marcodejongh/chai-webdriverio",


### PR DESCRIPTION
This should be ready for a release to fix the visible assertion bug.

Not sure if the tag will copy over here... doesn't look like it. So:
1. merge
2. git tag v0.4.1 (on master - ideally, although not necessary), and 
3. publish to npm