### PR TITLE
Add assertion enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.4.3:
+**Added feature:**
+- added `enabled` assertion
+
 ## 0.4.2:
 
 **Bug Fixes:**

--- a/src/assertions/enabled.js
+++ b/src/assertions/enabled.js
@@ -1,0 +1,25 @@
+import configWithDefaults from '../util/default-config';
+
+export default function enabled(client, chai, utils, options) {
+    const config = configWithDefaults(options);
+
+   chai.Assertion.addMethod('enabled', function() {
+        const negate = utils.flag(this, 'negate');
+        const selector =  utils.flag(this, 'object');
+        const immediately = utils.flag(this, 'immediately');
+
+       if (!immediately) {
+          client.waitForEnabled(selector, config.defaultWait, negate);
+        }
+
+       const isEnabled = client.isEnabled(selector);
+        const enabledArray = (Array.isArray(isEnabled)) ? isEnabled : [isEnabled];
+        const anyEnabled = enabledArray.includes(true);
+
+       this.assert(
+            anyEnabled,
+            `Expected ${selector} to be enabled but it is not`,
+            `Expected ${selector} to not be enabled but it is`
+       );
+    });
+}

--- a/src/index.js
+++ b/src/index.js
@@ -5,11 +5,12 @@ import count from './assertions/count';
 import text from './assertions/text';
 import value from './assertions/value';
 import focus from './assertions/focus';
+import enabled from './assertions/enabled';
 import immediately from './chains/immediately';
 
 export default function (client, options = {}) {
     return function chaiWebdriverIO(chai, utils) {
-        let methodsToAdd = [there, visible, count, text, immediately, value, focus];
+        let methodsToAdd = [there, visible, count, text, immediately, value, focus , enabled];
 
         methodsToAdd.forEach(function (methodToAdd) {
             methodToAdd(client, chai, utils, options);

--- a/test/assertions/enabled-test.js
+++ b/test/assertions/enabled-test.js
@@ -32,23 +32,7 @@ describe('enabled', () => {
             });
 
             it('Should call `waitForEnabled` without `reverse`', () => {
-                expect(fakeClient.waitForEnabled)
-                    .to.have.been.calledWith('.some-selector', 0, undefined);
-            });
-
-            describe('When the element is still not enabled after the wait time', () => {
-                let testError;
-
-                beforeEach(() => {
-                    testError = 'Element still not enabled';
-
-                    fakeClient.waitForEnabled.throws(new Error(testError));
-                });
-
-                it('Should throw an exception', () => {
-                    expect(() => expect('.some-selector').to.be.enabled())
-                        .to.throw(testError);
-                });
+                expect(fakeClient.waitForEnabled).to.have.been.calledWith('.some-selector', 0);
             });
         });
 
@@ -56,23 +40,7 @@ describe('enabled', () => {
             beforeEach(() => expect('.some-selector').to.not.be.enabled());
 
             it('Should call `waitForEnabled` with `reverse` true', () => {
-                expect(fakeClient.waitForEnabled)
-                    .to.have.been.calledWith('.some-selector', 0, true);
-            });
-
-            describe('When the element is still enabled after the wait time', () => {
-                let testError;
-
-                beforeEach(() => {
-                    testError = 'Element still enabled';
-
-                    fakeClient.waitForEnabled.throws(new Error(testError));
-                });
-
-                it('Should throw an exception', () => {
-                    expect(() => expect('.some-selector').to.not.be.enabled())
-                        .to.throw(testError);
-                });
+                expect(fakeClient.waitForEnabled).to.have.been.calledWith('.some-selector', 0, true);
             });
         });
 

--- a/test/assertions/enabled-test.js
+++ b/test/assertions/enabled-test.js
@@ -1,0 +1,178 @@
+import chai, { expect } from 'chai';
+import sinonChai from 'sinon-chai';
+import FakeClient from '../stubs/fake-client';
+import sinon from 'sinon';
+import enabled from '../../src/assertions/enabled';
+import immediately from '../../src/chains/immediately';
+
+//Using real chai, because it would be too much effort to stub/mock everything
+chai.use(sinonChai);
+
+describe('enabled', () => {
+    let fakeClient;
+
+    beforeEach(() => {
+        fakeClient = new FakeClient();
+
+        fakeClient.isEnabled.throws('ArgumentError');
+        fakeClient.isEnabled.withArgs('.some-selector').returns(false);
+
+        chai.use((chai, utils) => enabled(fakeClient, chai, utils));
+        chai.use((chai, utils) => immediately(fakeClient, chai, utils));
+    });
+
+    afterEach(() => fakeClient.__resetStubs__());
+
+    describe('When in synchronous mode', () => {
+        describe('When not negated', () => {
+            beforeEach(() => {
+                fakeClient.isEnabled.withArgs('.some-selector').returns(true);
+
+                expect('.some-selector').to.be.enabled();
+            });
+
+            it('Should call `waitForEnabled` without `reverse`', () => {
+                expect(fakeClient.waitForEnabled)
+                    .to.have.been.calledWith('.some-selector', 0, undefined);
+            });
+
+            describe('When the element is still not enabled after the wait time', () => {
+                let testError;
+
+                beforeEach(() => {
+                    testError = 'Element still not enabled';
+
+                    fakeClient.waitForEnabled.throws(new Error(testError));
+                });
+
+                it('Should throw an exception', () => {
+                    expect(() => expect('.some-selector').to.be.enabled())
+                        .to.throw(testError);
+                });
+            });
+        });
+
+        describe('When negated', () => {
+            beforeEach(() => expect('.some-selector').to.not.be.enabled());
+
+            it('Should call `waitForEnabled` with `reverse` true', () => {
+                expect(fakeClient.waitForEnabled)
+                    .to.have.been.calledWith('.some-selector', 0, true);
+            });
+
+            describe('When the element is still enabled after the wait time', () => {
+                let testError;
+
+                beforeEach(() => {
+                    testError = 'Element still enabled';
+
+                    fakeClient.waitForEnabled.throws(new Error(testError));
+                });
+
+                it('Should throw an exception', () => {
+                    expect(() => expect('.some-selector').to.not.be.enabled())
+                        .to.throw(testError);
+                });
+            });
+        });
+
+        describe('When the element is enabled', () => {
+            beforeEach(() => {
+                fakeClient.isEnabled.withArgs('.some-selector').returns(true);
+            });
+
+            it('Should not throw an exception', () => {
+                expect('.some-selector').to.be.enabled();
+            });
+
+            describe('When given a default wait time' , () => {
+                beforeEach(() => {
+                  chai.use((chai, utils) => enabled(fakeClient, chai, utils, {defaultWait: 100}));
+
+                  expect('.some-selector').to.be.enabled();
+                });
+
+                it('Should call `waitForEnabled` with the specified wait time', () => {
+                    expect(fakeClient.waitForEnabled)
+                        .to.have.been.calledWith('.some-selector', 100);
+                });
+            });
+
+            describe('When the call is chained with `immediately`', () => {
+                beforeEach(() => {
+                    expect('.some-selector').to.be.immediately().enabled();
+                });
+
+                it('Should not wait for the element to be enabled', () => {
+                    expect(fakeClient.waitForEnabled).to.not.have.been.called;
+                });
+            });
+
+            describe('When the assertion is negated', () => {
+                it('Should throw an exception', () => {
+                    expect(() => expect('.some-selector').to.not.be.enabled()).to.throw();
+                });
+            });
+        });
+
+        describe('When the element is not enabled', () => {
+            beforeEach(() => {
+                fakeClient.isEnabled.withArgs('.some-selector').returns(false);
+            });
+
+            it('Should throw an exception', () => {
+                expect(() => expect('.some-selector').to.be.enabled()).to.throw();
+            });
+
+            describe('When the assertion is negated', () => {
+                it('Should not throw an exception', () => {
+                    expect('.some-selector').to.not.be.enabled();
+                });
+            });
+        });
+
+        describe('When multiple matching elements exist', () => {
+            describe('When any one is enabled', () => {
+                beforeEach(() => {
+                    fakeClient.isEnabled.withArgs('.some-selector').returns([true, false]);
+                });
+
+                it('Should not throw an exception', () => {
+                    expect('.some-selector').to.be.enabled();
+                });
+
+                describe('When the call is chained with `immediately`', () => {
+                    beforeEach(() => {
+                        expect('.some-selector').to.be.immediately().enabled();
+                    });
+
+                    it('Should not wait for the element to be enabled', () => {
+                        expect(fakeClient.waitForEnabled).to.not.have.been.called;
+                    });
+                });
+
+                describe('When the assertion is negated', () => {
+                    it('Should throw an exception', () => {
+                        expect(() => expect('.some-selector').to.not.be.enabled()).to.throw();
+                    });
+                });
+            });
+
+            describe('When none are enabled', () => {
+                beforeEach(() => {
+                    fakeClient.isEnabled.withArgs('.some-selector').returns([false, false]);
+                });
+
+                it('Should throw an exception', () => {
+                    expect(() => expect('.some-selector').to.be.enabled()).to.throw();
+                });
+
+                describe('When the assertion is negated', () => {
+                    it('Should not throw an exception', () => {
+                        expect('.some-selector').to.not.be.enabled();
+                    });
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
At this moment it seems that we lacking the assertion for `enabled`. This pull request is intended to add `enabled` to the project.

Now we can do `expect(selector).to.be.enabled()`.