### PR TITLE
fix: support chai 4.1.x peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     "webdriverio": "^4.6.2"
   },
   "peerDependencies": {
-    "chai": "~4.0.1"
+    "chai": "^4.0.1"
   }
 }


### PR DESCRIPTION
Build is failing with `yarn` when using with `chai@4.1.2` since this module was expecting `4.0.x` due to the use of `~` in `~4.0.1` in its `peerDependencies`. But `chai` `4.1.2` should be compatible with `4.0.x` based on semantic versioning, so it should be safe to allow.
