### PR TITLE
Fix TypeScript typings to work with latest WebdriverIO types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-/// <reference types="webdriverio" />
+/// <reference types="webdriver" />
 /// <reference types="chai" />
 
 declare namespace Chai {
@@ -15,6 +15,10 @@ declare namespace Chai {
 }
 
 declare module 'chai-webdriverio' {
-    function chaiWebdriverIO(client: WebdriverIO.Client<void>, options?: any): (chai: any, utils: any) => void;
+    interface Options {
+        defaultWait?: number
+    }
+
+    function chaiWebdriverIO(client: WebDriver.Client | WebDriver.ClientAsync, options?: Options): (chai: any, utils: any) => void;
     export = chaiWebdriverIO;
 }


### PR DESCRIPTION
## Problem

Current typings prevent WebdriverIO in combination with @wdio/sync to compile.

## Solution

Changed typings so that it will work both with WebdriverIOAsync and @wdio/sync

## Further comments

Also added interface for Options object.
